### PR TITLE
fix(#61): allTrades 날짜 정렬 후 recent/older 분할

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -59,9 +59,12 @@ async function buildEvalData(apt) {
       const nm  = (item.aptNm || '').trim()
       const amt = parseInt((item.dealAmount || '').replace(/,/g, ''), 10)
       if (nameSim(nm, apt.kaptName) < 0.6 || isNaN(amt)) return
-      allTrades.push({ amt, area: parseFloat(item.excluUseAr) || 0 })
+      const dealYmd = `${item.dealYear}${String(item.dealMonth || 0).padStart(2,'0')}${String(item.dealDay || 0).padStart(2,'0')}`
+      allTrades.push({ amt, area: parseFloat(item.excluUseAr) || 0, dealYmd })
     })
   })
+
+  allTrades.sort((a, b) => b.dealYmd.localeCompare(a.dealYmd))
 
   const half = Math.ceil(allTrades.length / 2)
   const { recentAvg, direction } = calcPriceSignal(allTrades.slice(0, half), allTrades.slice(half))


### PR DESCRIPTION
## 수정 내용

| 이슈 | 심각도 | 파일 | 수정 내용 |
|------|--------|------|-----------|
| #61 | High | `src/App.jsx` | allTrades에 `dealYmd` 추가 후 날짜 내림차순 정렬, 이후 recent/older 분할 |

## 변경 상세

`buildEvalData()`에서 allTrades를 날짜 정렬 없이 반으로 나눠 `calcPriceSignal`에 전달하여 시세 방향성(상승/하락/보합)이 틀리게 계산되던 버그 수정.

- 각 trade 항목에 `dealYmd` (YYYYMMDD 형식) 저장
- `allTrades.sort((a, b) => b.dealYmd.localeCompare(a.dealYmd))` 로 최신순 정렬 후 분할

Closes #61