### PR TITLE
fix(#45,#49,#50): voice 빈 따옴표 방지, stories/vibe Promise.allSettled

### DIFF
--- a/api/stories.js
+++ b/api/stories.js
@@ -16,13 +16,14 @@ export default async function handler(req, res) {
   const cafeQ = [location ? `${location} 육아` : `${aptName} 육아`, location ? `${location} 임장` : `${aptName} 임장 후기`]
 
   try {
-    const [b1, b2, b3, c1, c2] = await Promise.all([
+    const settled = await Promise.allSettled([
       naverSearch(NAVER_BLOG, blogQ[0], 5),
       naverSearch(NAVER_BLOG, blogQ[1], 5),
       naverSearch(NAVER_BLOG, blogQ[2], 5),
       naverSearch(NAVER_CAFE, cafeQ[0], 4),
       naverSearch(NAVER_CAFE, cafeQ[1], 4),
     ])
+    const [b1, b2, b3, c1, c2] = settled.map(r => r.status === 'fulfilled' ? r.value : [])
     const seen = new Set()
     const stories = [...b1, ...b2, ...b3, ...c1, ...c2]
       .filter(item => {

--- a/api/vibe.js
+++ b/api/vibe.js
@@ -16,13 +16,14 @@ export default async function handler(req, res) {
   if (!process.env.ANTHROPIC_API_KEY) return res.status(500).json({ error: 'Anthropic API 키 없음' })
 
   try {
-    const [blog1, blog2, cafe, news, kin] = await Promise.all([
+    const settled = await Promise.allSettled([
       naverSearch(NAVER_BLOG, `${aptName} 살아보니`),
       naverSearch(NAVER_BLOG, `${aptName} 입주 후기`),
       naverSearch(NAVER_CAFE, location ? `${location} 실거주 후기` : `${aptName} 후기`),
       naverSearch(NAVER_NEWS, `${aptName}`, 3),
       naverSearch(NAVER_KIN,  `${aptName} 어때요`, 4),
     ])
+    const [blog1, blog2, cafe, news, kin] = settled.map(r => r.status === 'fulfilled' ? r.value : [])
 
     const seen = new Set()
     const dedup = (items) => items.filter(i => {

--- a/src/EvalCard.jsx
+++ b/src/EvalCard.jsx
@@ -62,7 +62,7 @@ export default function EvalCard({ apt, onDetail }) {
       )}
 
       {/* 실거주 한마디 */}
-      {apt.voice?.link && isValidUrl(apt.voice.link) && (
+      {apt.voice?.link && isValidUrl(apt.voice.link) && (apt.voice.description?.slice(0, 50) || apt.voice.title?.slice(0, 40)) && (
         <a className="eval-voice" href={apt.voice.link} target="_blank" rel="noopener noreferrer">
           🗣 "{apt.voice.description?.slice(0, 50) || apt.voice.title?.slice(0, 40)}"
         </a>


### PR DESCRIPTION
## 수정 내용

| 이슈 | 심각도 | 파일 | 수정 내용 |
|------|--------|------|-----------|
| #45 | Medium | `src/EvalCard.jsx` | voice text 비어있을 때 `🗣 ""` 렌더링 방지 |
| #49 | Medium | `api/stories.js` | `Promise.all` → `Promise.allSettled` (쿼리 1개 실패해도 나머지 정상 노출) |
| #50 | Medium | `api/vibe.js` | `Promise.all` → `Promise.allSettled` (검색 소스 1개 실패해도 AI 요약 유지) |

Closes #45, #49, #50