### PR TITLE
fix(#63): 아파트명 공백 정규화 검색 지원

### DIFF
--- a/api/search.js
+++ b/api/search.js
@@ -24,8 +24,12 @@ export default function handler(req, res) {
 
   const list = loadAptList()
   const query = q.trim()
+  const normalQ = query.replace(/\s+/g, '')
   const results = list
-    .filter(i => i.kaptName?.includes(query))
+    .filter(i => {
+      const nm = i.kaptName || ''
+      return nm.includes(query) || nm.replace(/\s+/g, '').includes(normalQ)
+    })
     .slice(0, 20)
 
   return res.json(results)


### PR DESCRIPTION
## 수정 내용

| 이슈 | 심각도 | 파일 | 수정 내용 |
|------|--------|------|-----------|
| #63 | Medium | `api/search.js` | 검색어와 아파트명 모두 공백 제거 후 비교하여 "고덕그라시움" → "고덕 그라시움" 검색 가능 |

## 동작 방식

- 원본 query 로 기존 `includes` 매칭 우선
- 공백 제거한 normalQ 로 추가 매칭 (공백 유무 무관하게 검색 가능)

Closes #63