### PR TITLE
fix(#58): 모바일 자동완성 터치 시 닫힘 방지

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -136,12 +136,16 @@ export default function App() {
   const [showSugg, setShowSugg]       = useState(false)
   const [activeSugg, setActiveSugg]   = useState(-1)
   const searchRef    = useRef(null)
+  const suggRef      = useRef(null)
   const debounceRef  = useRef(null)
   const suggAbortRef = useRef(null) // #36: race condition 방지
 
   useEffect(() => {
     const handleClick = (e) => {
-      if (searchRef.current && !searchRef.current.contains(e.target)) setShowSugg(false)
+      if (searchRef.current && !searchRef.current.contains(e.target) &&
+          !(suggRef.current && suggRef.current.contains(e.target))) {
+        setShowSugg(false)
+      }
     }
     document.addEventListener('mousedown', handleClick)
     return () => document.removeEventListener('mousedown', handleClick)
@@ -250,7 +254,7 @@ export default function App() {
           <button className="search-btn" onClick={() => { setShowSugg(false); handleSearch(query) }}>검색</button>
         </div>
         {showSugg && suggestions.length > 0 && (
-          <ul className="sugg-list">
+          <ul className="sugg-list" ref={suggRef}>
             {suggestions.map((apt, i) => (
               <li
                 key={apt.kaptCode}


### PR DESCRIPTION
## 수정 내용

| 이슈 | 심각도 | 파일 | 수정 내용 |
|------|--------|------|-----------|
| #58 | Medium | `src/App.jsx` | `suggRef` 추가 후 mousedown 핸들러에서 제안 목록 내부 터치는 닫힘 방지 |

## 변경 상세

`sugg-list` `<ul>`에 `suggRef`를 달고, 외부 클릭 핸들러에서 `suggRef.current.contains(e.target)` 체크를 추가하여 모바일 터치 이벤트 순서 관계없이 선택 전 목록 닫힘을 방지합니다.

Closes #58