### PR TITLE
fix(#55,#62): toast 타이머 중복 방지, stories link 프로토콜 검증

### DIFF
--- a/api/stories.js
+++ b/api/stories.js
@@ -28,6 +28,7 @@ export default async function handler(req, res) {
       .filter(item => {
         const t = stripHtml(item.title)
         if (isCommercial(t) || seen.has(item.link)) return false
+        if (!item.link?.startsWith('http://') && !item.link?.startsWith('https://')) return false
         seen.add(item.link)
         return true
       })

--- a/src/DetailReport.jsx
+++ b/src/DetailReport.jsx
@@ -9,12 +9,14 @@ const TABS = ['동네·이야기', '시세']
 export default function DetailReport({ apt, onBack }) {
   const [tab, setTab] = useState('동네·이야기')
   const [toast, setToast] = useState(false)
+  const toastTimerRef = useRef(null)
 
   const handleCollect = useCallback(() => {
     const url = `${window.location.origin}/?q=${encodeURIComponent(apt.aptNm)}`
     navigator.clipboard.writeText(url).then(() => {
+      clearTimeout(toastTimerRef.current)
       setToast(true)
-      setTimeout(() => setToast(false), 2800)
+      toastTimerRef.current = setTimeout(() => setToast(false), 2800)
     }).catch(() => {
       // clipboard API 미지원 fallback
       const el = document.createElement('textarea')
@@ -25,10 +27,13 @@ export default function DetailReport({ apt, onBack }) {
       el.select()
       document.execCommand('copy')
       document.body.removeChild(el)
+      clearTimeout(toastTimerRef.current)
       setToast(true)
-      setTimeout(() => setToast(false), 2800)
+      toastTimerRef.current = setTimeout(() => setToast(false), 2800)
     })
   }, [apt.aptNm])
+
+  useEffect(() => () => clearTimeout(toastTimerRef.current), [])
 
   return (
     <div className="detail-report">


### PR DESCRIPTION
## 수정 내용

| 이슈 | 심각도 | 파일 | 수정 내용 |
|------|--------|------|-----------|
| #62 | Medium | `src/DetailReport.jsx` | handleCollect 빠른 클릭 시 toast 타이머 중복 방지 (`toastTimerRef` + clearTimeout) |
| #55 | Medium | `api/stories.js` | story link 필드 `http(s)://` 프로토콜 검증 추가 |

Closes #55, #62