### PR TITLE
fix(#73,#74,#84): 소형평형 필터, 날짜기반 시세 분할, story-card XSS 방지

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,7 +2,7 @@
 import { useState, useCallback, useEffect, useRef } from 'react'
 import { DONG, HINT_SEARCHES } from './data.js'
 import { getYM, getLifeConditions, getVerdict, calcPriceSignal, nameSim } from './utils.js'
-import { PRICE_HIGH, PRICE_LOW, FETCH_TIMEOUT } from './constants.js'
+import { PRICE_HIGH, PRICE_LOW, FETCH_TIMEOUT, MIN_AREA_SQM } from './constants.js'
 import EvalCard from './EvalCard.jsx'
 import DetailReport from './DetailReport.jsx'
 
@@ -57,18 +57,21 @@ async function buildEvalData(apt) {
     if (!items) return
     const arr = Array.isArray(items) ? items : [items]
     arr.forEach(item => {
-      const nm  = (item.aptNm || '').trim()
-      const amt = parseInt((item.dealAmount || '').replace(/,/g, ''), 10)
-      if (nameSim(nm, apt.kaptName) < 0.6 || isNaN(amt)) return
+      const nm   = (item.aptNm || '').trim()
+      const amt  = parseInt((item.dealAmount || '').replace(/,/g, ''), 10)
+      const area = parseFloat(item.excluUseAr) || 0
+      if (nameSim(nm, apt.kaptName) < 0.6 || isNaN(amt) || area < MIN_AREA_SQM) return
       const dealYmd = `${item.dealYear}${String(item.dealMonth || 0).padStart(2,'0')}${String(item.dealDay || 0).padStart(2,'0')}`
-      allTrades.push({ amt, area: parseFloat(item.excluUseAr) || 0, dealYmd })
+      allTrades.push({ amt, area, dealYmd })
     })
   })
 
   allTrades.sort((a, b) => b.dealYmd.localeCompare(a.dealYmd))
 
-  const half = Math.ceil(allTrades.length / 2)
-  const { recentAvg, direction } = calcPriceSignal(allTrades.slice(0, half), allTrades.slice(half))
+  const cutoff = ymList[2]
+  const recentTrades = allTrades.filter(t => t.dealYmd.slice(0, 6) >= cutoff)
+  const olderTrades  = allTrades.filter(t => t.dealYmd.slice(0, 6) <  cutoff)
+  const { recentAvg, direction } = calcPriceSignal(recentTrades, olderTrades)
 
   let priceLabel = '적정'
   if (recentAvg > PRICE_HIGH) priceLabel = '비쌈'

--- a/src/DetailReport.jsx
+++ b/src/DetailReport.jsx
@@ -4,6 +4,11 @@ import { fP, fR, getYM, formatDealDate, nameSim, getLifeConditions } from './uti
 import { FETCH_TIMEOUT, MIN_AREA_SQM, SQM_TO_PYEONG, KR_LAT, KR_LON } from './constants.js'
 import { DONG } from './data.js'
 
+function isValidUrl(url) {
+  try { const { protocol } = new URL(url); return protocol === 'http:' || protocol === 'https:' }
+  catch { return false }
+}
+
 const TABS = ['동네·이야기', '시세']
 
 export default function DetailReport({ apt, onBack }) {
@@ -293,7 +298,9 @@ function NeighborhoodStoriesTab({ dong, aptNm, addr }) {
           <div className="detail-empty">실거주 후기를 찾지 못했습니다</div>
         ) : (
           <div className="stories-tab">
-            {stories.map((s, i) => (
+            {stories
+              .filter(s => s.link && isValidUrl(s.link))
+              .map((s, i) => (
               <a key={i} className="story-card" href={s.link} target="_blank" rel="noopener noreferrer">
                 <div className="story-card-title">{s.title}</div>
                 {s.description && <div className="story-card-desc">{s.description}</div>}


### PR DESCRIPTION
## 수정 내용

| 이슈 | 심각도 | 파일 | 수정 내용 |
|------|--------|------|-----------|
| #73 | Medium | `src/App.jsx` | `buildEvalData()`에 `MIN_AREA_SQM` 필터 추가 — 소형 평형 거래 제외로 EvalCard 평균가 정확도 개선 |
| #74 | Medium | `src/App.jsx` | 거래 건수 기반 절반 split → 날짜 기반 3개월 경계 split (`ymList[2]` cutoff) |
| #84 | Medium | `src/DetailReport.jsx` | `isValidUrl()` 추가, story-card `<a href>` 렌더링 전 프로토콜 검증 (`javascript:` XSS 방지) |

Closes #73, #74, #84