### PR TITLE
fix(#89,#90): vibe AI 요약 수정 — maxDuration 30초 + anthropic-version 올바른 버전

### DIFF
--- a/api/vibe.js
+++ b/api/vibe.js
@@ -1,5 +1,5 @@
 // 수근수근 요약 — 블로그/카페/뉴스/지식인 수집 후 Claude로 3줄 요약
-export const config = { regions: ['icn1'] }
+export const config = { maxDuration: 30, regions: ['icn1'] }
 
 import { stripHtml, naverSearch, NAVER_BLOG, NAVER_CAFE, NAVER_NEWS, NAVER_KIN } from './_utils.js'
 
@@ -47,7 +47,7 @@ export default async function handler(req, res) {
       method: 'POST',
       headers: {
         'x-api-key': process.env.ANTHROPIC_API_KEY,
-        'anthropic-version': '2024-06-01',
+        'anthropic-version': '2023-06-01',
         'content-type': 'application/json',
       },
       body: JSON.stringify({


### PR DESCRIPTION
## Summary

- `api/vibe.js`에 `maxDuration: 30` 추가 — Vercel 기본 10초 타임아웃으로 AI 요약 항상 실패하던 문제 해결 (closes #89)
- `anthropic-version: '2024-06-01'` → `'2023-06-01'` 수정 — 잘못된 API 버전 헤더로 Claude 호출 오류 해결 (closes #90)

## Changes

```diff
- export const config = { regions: ['icn1'] }
+ export const config = { maxDuration: 30, regions: ['icn1'] }

-   'anthropic-version': '2024-06-01',
+   'anthropic-version': '2023-06-01',
```

## Test plan

- [ ] 배포 후 아파트 상세 리포트 → 동네·이야기 탭 → "지금 이 동네 분위기" AI 요약 3줄 표시 확인
- [ ] Vercel Functions 로그에서 vibe 함수 정상 완료(200) 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)