### PR TITLE
fix(#88): URL 파라미터 ?q= 검색 자동 실행

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -129,6 +129,11 @@ export default function App() {
     }
   }, [])
 
+  useEffect(() => {
+    const q = new URLSearchParams(window.location.search).get('q')
+    if (q) { setQuery(q); handleSearch(q) }
+  }, [handleSearch])
+
   const goHome = useCallback(() => {
     setDetailApt(null)
     setCards([])


### PR DESCRIPTION
## 변경 사항

`/?q=아파트명` URL로 접근 시 검색이 자동 실행되지 않던 버그 수정.

수집하기 버튼으로 공유한 링크를 열면 이제 바로 검색 결과가 표시됩니다.

## 원인

`App.jsx`가 마운트 시 `window.location.search`를 읽지 않아 URL 파라미터가 무시됨.

## 수정 내용

- `App.jsx`에 마운트 시 `?q=` 파라미터를 읽어 `handleSearch` 호출하는 `useEffect` 추가

Closes #88