### PR TITLE
fix(#87,#90): KakaoMap SDK 비동기 로드 race condition 수정, vibe.js anthropic-version 수정

### DIFF
--- a/api/vibe.js
+++ b/api/vibe.js
@@ -47,7 +47,7 @@ export default async function handler(req, res) {
       method: 'POST',
       headers: {
         'x-api-key': process.env.ANTHROPIC_API_KEY,
-        'anthropic-version': '2024-06-01',
+        'anthropic-version': '2023-06-01',
         'content-type': 'application/json',
       },
       body: JSON.stringify({

--- a/src/DetailReport.jsx
+++ b/src/DetailReport.jsx
@@ -350,6 +350,16 @@ function KakaoMap({ aptNm, addr }) {
   const [coords, setCoords] = useState(null)
   const [failed, setFailed] = useState(false)
   const [mapError, setMapError] = useState(false)
+  const [kakaoReady, setKakaoReady] = useState(false)
+
+  useEffect(() => {
+    if (window.kakao?.maps) { setKakaoReady(true); return }
+    const timer = setInterval(() => {
+      if (window.kakao?.maps) { setKakaoReady(true); clearInterval(timer) }
+    }, 100)
+    const timeout = setTimeout(() => { clearInterval(timer); setMapError(true) }, 5000)
+    return () => { clearInterval(timer); clearTimeout(timeout) }
+  }, [])
 
   useEffect(() => {
     const cacheKey = `${aptNm}|${addr}`
@@ -373,13 +383,12 @@ function KakaoMap({ aptNm, addr }) {
   }, [aptNm, addr])
 
   useEffect(() => {
-    if (!coords || !mapRef.current) return
-    if (!window.kakao?.maps) { setMapError(true); return }
+    if (!coords || !mapRef.current || !kakaoReady) return
     const { kakao } = window
     const center = new kakao.maps.LatLng(coords.lat, coords.lon)
     const map = new kakao.maps.Map(mapRef.current, { center, level: 3 })
     new kakao.maps.Marker({ position: center, map })
-  }, [coords])
+  }, [coords, kakaoReady])
 
   if (failed || mapError) return <div className="osm-map osm-map-loading">지도를 불러올 수 없습니다</div>
   if (!coords) return <div className="osm-map osm-map-loading">지도 불러오는 중...</div>


### PR DESCRIPTION
## 변경 사항

### #87 — KakaoMap SDK 비동기 로드 race condition

Kakao Maps SDK가 `async`로 로드되어 컴포넌트 마운트 시 아직 없을 수 있는데, 기존 코드는 즉시 `setMapError(true)`를 호출해 지도가 영구적으로 오류 상태가 되는 버그.

**수정**: `kakaoReady` 상태 추가. 마운트 시 100ms 간격 폴링으로 SDK 로드를 기다리고, 5초 후에도 없으면 `mapError`로 폴백.

### #90 — vibe.js anthropic-version 헤더 수정

`api/vibe.js`에서 `'anthropic-version': '2024-06-01'`은 유효하지 않은 버전 — `'2023-06-01'`로 수정.

## 수정 파일

- `src/DetailReport.jsx` — `KakaoMap` 컴포넌트에 SDK 폴링 로직 추가
- `api/vibe.js` — anthropic-version 헤더 수정

Closes #87, Closes #90