### PR TITLE
fix(#44,#46): 검색 결과 수 피드백, vibe·stories 에러 상태 구분

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -99,6 +99,7 @@ export default function App() {
   const [loading, setLoading]     = useState(false)
   const [error, setError]         = useState(null)
   const [detailApt, setDetailApt] = useState(null)
+  const [totalCount, setTotalCount] = useState(0)
 
   // #37: finally로 setLoading 일원화
   const handleSearch = useCallback(async (q) => {
@@ -106,6 +107,7 @@ export default function App() {
     setLoading(true)
     setError(null)
     setCards([])
+    setTotalCount(0)
     setDetailApt(null)
 
     try {
@@ -122,6 +124,7 @@ export default function App() {
         return
       }
       setCards(filtered)
+      setTotalCount(Array.isArray(res) ? res.length : 0)
     } catch {
       setError('데이터를 불러오는 중 오류가 발생했습니다')
     } finally {
@@ -134,6 +137,7 @@ export default function App() {
     setCards([])
     setQuery('')
     setError(null)
+    setTotalCount(0)
   }, [])
 
   const [suggestions, setSuggestions] = useState([])
@@ -287,6 +291,9 @@ export default function App() {
           {cards.map((apt) => (
             <EvalCard key={apt.kaptCode} apt={apt} onDetail={() => setDetailApt(apt)} />
           ))}
+          {totalCount > cards.length && (
+            <div className="search-count-hint">{totalCount}개 중 상위 {cards.length}개 표시</div>
+          )}
         </div>
       )}
     </div>

--- a/src/DetailReport.jsx
+++ b/src/DetailReport.jsx
@@ -231,21 +231,23 @@ function NeighborhoodStoriesTab({ dong, aptNm, addr }) {
   const conditions = getLifeConditions(dong)
   const [vibe, setVibe] = useState(null)
   const [vibeLoading, setVibeLoading] = useState(true)
+  const [vibeError, setVibeError] = useState(false)
   const [stories, setStories] = useState([])
   const [storiesLoading, setStoriesLoading] = useState(true)
+  const [storiesError, setStoriesError] = useState(false)
   useEffect(() => {
     const controller = new AbortController()
     const { signal } = controller
-    setVibe(null); setVibeLoading(true)
-    setStories([]); setStoriesLoading(true)
+    setVibe(null); setVibeLoading(true); setVibeError(false)
+    setStories([]); setStoriesLoading(true); setStoriesError(false)
     fetch(`/api/vibe?aptName=${encodeURIComponent(aptNm)}&location=${encodeURIComponent(dong || '')}`, { signal })
       .then(r => r.json())
       .then(data => { setVibe(data?.lines || []); setVibeLoading(false) })
-      .catch(e => { if (e.name !== 'AbortError') { setVibe([]); setVibeLoading(false) } })
+      .catch(e => { if (e.name !== 'AbortError') { setVibeError(true); setVibeLoading(false) } })
     fetch(`/api/stories?aptName=${encodeURIComponent(aptNm)}&location=${encodeURIComponent(dong || '')}`, { signal })
       .then(r => r.json())
       .then(data => { setStories(Array.isArray(data) ? data : []); setStoriesLoading(false) })
-      .catch(e => { if (e.name !== 'AbortError') { setStories([]); setStoriesLoading(false) } })
+      .catch(e => { if (e.name !== 'AbortError') { setStoriesError(true); setStoriesLoading(false) } })
     return () => controller.abort()
   }, [aptNm, dong])
 
@@ -256,10 +258,12 @@ function NeighborhoodStoriesTab({ dong, aptNm, addr }) {
         <div className="vibe-card-title">지금 이 동네 분위기</div>
         {vibeLoading ? (
           <div className="vibe-loading">AI 요약 생성 중...</div>
+        ) : vibeError ? (
+          <div className="vibe-empty">일시적인 오류가 발생했습니다</div>
         ) : vibe && vibe.length > 0 ? (
           <ul className="vibe-lines">{vibe.map((line, i) => <li key={i}>{line}</li>)}</ul>
         ) : (
-          <div className="vibe-empty">요약을 생성하지 못했습니다</div>
+          <div className="vibe-empty">요약 정보가 없습니다</div>
         )}
       </div>
 
@@ -289,6 +293,8 @@ function NeighborhoodStoriesTab({ dong, aptNm, addr }) {
       <Accordion label="블로그 · 카페 후기" count={stories?.length ?? null}>
         {storiesLoading ? (
           <div className="detail-loading">후기 불러오는 중...</div>
+        ) : storiesError ? (
+          <div className="detail-empty">일시적인 오류로 후기를 불러오지 못했습니다</div>
         ) : !stories || stories.length === 0 ? (
           <div className="detail-empty">실거주 후기를 찾지 못했습니다</div>
         ) : (


### PR DESCRIPTION
## 변경 사항

### #44 — 검색 결과 수 UX 피드백

검색 결과가 5개로 제한될 때 총 몇 개 중 몇 개인지 알려주는 힌트 표시 추가.

- `totalCount` 상태 추가
- 검색 API 전체 결과 수 추적 → "N개 중 상위 5개 표시" 힌트 출력

### #46 — vibe·stories API 에러 vs 빈 결과 구분

API 오류 시 빈 결과와 동일한 UI가 표시되어 사용자가 혼란스러웠던 문제 수정.

- `vibeError` / `storiesError` 상태 추가
- 에러 시: "일시적인 오류가 발생했습니다"
- 빈 결과 시: "요약 정보가 없습니다" (기존과 구분)

## 수정 파일

- `src/App.jsx` — totalCount 상태 + 힌트 UI
- `src/DetailReport.jsx` — NeighborhoodStoriesTab 에러 상태 분리

Closes #44, Closes #46