### PR TITLE
fix(saju): tool-use 전환 + 안정화 + 일반인 톤

### DIFF
--- a/api/__tests__/saju.test.js
+++ b/api/__tests__/saju.test.js
@@ -1,0 +1,257 @@
+// node:test — node --test api/__tests__/saju.test.js
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import { calcFourPillars, processToolResponse, SAJU_TOOL } from '../saju.js'
+
+// ───────────────────────────────────────────────────────────────
+// 1. 만세력 계산 (calcFourPillars)
+// ───────────────────────────────────────────────────────────────
+describe('calcFourPillars — 만세력 4주 8자', () => {
+  test('1991.02.13 진시 (전이준) — 일주 甲寅, 시주 戊辰', () => {
+    const fp = calcFourPillars(1991, 2, 13, '진')
+    assert.equal(fp.day.kor, '갑인', '일주 한글')
+    assert.equal(fp.day.han, '甲寅', '일주 한자')
+    assert.equal(fp.ilgan,  '갑',   '일간')
+    assert.ok(fp.hour, '시주가 있어야 함')
+    assert.equal(fp.hour.kor, '무진', '시주 (갑일 진시 = 무진)')
+    assert.equal(fp.hour.han, '戊辰')
+  })
+
+  test('1996.08.27 유시 (전혜빈) — 일주 丙申, 시주 丁酉', () => {
+    const fp = calcFourPillars(1996, 8, 27, '유')
+    assert.equal(fp.day.kor, '병신')
+    assert.equal(fp.day.han, '丙申')
+    assert.equal(fp.ilgan,  '병')
+    assert.equal(fp.hour.kor, '정유', '시주 (병일 유시 = 정유)')
+  })
+
+  test('si 미입력 시 hour = null', () => {
+    const fp = calcFourPillars(1996, 8, 27, null)
+    assert.equal(fp.hour, null)
+  })
+
+  test('잘못된 si는 hour = null', () => {
+    const fp = calcFourPillars(1996, 8, 27, '잘못된값')
+    assert.equal(fp.hour, null)
+  })
+
+  test('필수 필드 — year/month/day/ilgan 모두 존재', () => {
+    const fp = calcFourPillars(2000, 6, 15, '오')
+    for (const k of ['year', 'month', 'day']) {
+      assert.ok(fp[k].kor, `${k}.kor`)
+      assert.ok(fp[k].han, `${k}.han`)
+      assert.ok(fp[k].ohaeng, `${k}.ohaeng`)
+    }
+    assert.ok(fp.ilgan)
+  })
+})
+
+// ───────────────────────────────────────────────────────────────
+// 2. processToolResponse — Anthropic 응답 검증
+// ───────────────────────────────────────────────────────────────
+function fixtureRegions(n = 3) {
+  return Array.from({ length: n }, (_, i) => ({
+    gu: `구${i+1}`, rank: i+1, score: 90 - i*5,
+    scoreBreakdown: {
+      ohaengMatch:  { score: 22, reason: 'r' },
+      jimingOhaeng: { score: 22, reason: 'r' },
+      landscape:    { score: 23, reason: 'r' },
+      lifeEnergy:   { score: 23, reason: 'r' },
+    },
+    jiming: 'j', whyThisGu: 'w', dailyLife: 'd',
+  }))
+}
+
+function fixtureToolUseResponse(overrides = {}) {
+  const input = {
+    ilgan: '甲木',
+    plainSummary: '당신은 활동적 사주예요. 차분한 동네가 잘 맞아요.',
+    saju: { ohaengDist: '木 과다', sinkang: '신강', yongshin: '水', yongShinReason: 'r', daewon: 'd', sewon: 's' },
+    timing: { isGoodYear: true, timingScore: 80, reason: 'r', bestMonths: 'm' },
+    regions: fixtureRegions(3),
+    regionComparison: 'c',
+    warning: { year: '2028년', reason: 'r', action: 'a' },
+    summary: 's',
+    finalVerdict: 'v',
+    ...overrides,
+  }
+  return {
+    stop_reason: 'tool_use',
+    content: [{ type: 'tool_use', name: SAJU_TOOL.name, input }],
+    usage: { output_tokens: 1500 },
+  }
+}
+
+describe('processToolResponse — 정상 케이스', () => {
+  test('정상 tool_use 응답 — ok', () => {
+    const r = processToolResponse(fixtureToolUseResponse())
+    assert.equal(r.ok, true)
+    assert.equal(r.result.ilgan, '甲木')
+    assert.equal(r.result.regions.length, 3)
+  })
+
+  test('text 블록과 tool_use 블록이 섞여 있어도 tool_use만 추출', () => {
+    const data = {
+      stop_reason: 'tool_use',
+      content: [
+        { type: 'text', text: '분석을 시작합니다...' },
+        { type: 'tool_use', name: SAJU_TOOL.name, input: fixtureToolUseResponse().content[0].input },
+        { type: 'text', text: '추가 설명입니다' },
+      ],
+    }
+    const r = processToolResponse(data)
+    assert.equal(r.ok, true)
+  })
+})
+
+describe('processToolResponse — 실패 케이스', () => {
+  test('max_tokens 도달', () => {
+    const r = processToolResponse({ stop_reason: 'max_tokens', content: [] })
+    assert.equal(r.ok, false)
+    assert.equal(r.errorType, 'max_tokens')
+  })
+
+  test('tool_use 블록 없음 (text만)', () => {
+    const r = processToolResponse({ stop_reason: 'end_turn', content: [{ type: 'text', text: '...' }] })
+    assert.equal(r.ok, false)
+    assert.equal(r.errorType, 'no_tool_use')
+  })
+
+  test('잘못된 tool 이름', () => {
+    const data = {
+      stop_reason: 'tool_use',
+      content: [{ type: 'tool_use', name: 'wrong_tool', input: { regions: fixtureRegions(3) } }],
+    }
+    const r = processToolResponse(data)
+    assert.equal(r.ok, false)
+    assert.equal(r.errorType, 'no_tool_use')
+  })
+
+  test('content가 없음 (undefined)', () => {
+    const r = processToolResponse({ stop_reason: 'tool_use' })
+    assert.equal(r.ok, false)
+    assert.equal(r.errorType, 'no_tool_use')
+  })
+
+  test('content가 배열이 아님', () => {
+    const r = processToolResponse({ stop_reason: 'tool_use', content: 'invalid' })
+    assert.equal(r.ok, false)
+    assert.equal(r.errorType, 'no_tool_use')
+  })
+
+  test('input이 누락', () => {
+    const data = {
+      stop_reason: 'tool_use',
+      content: [{ type: 'tool_use', name: SAJU_TOOL.name }],
+    }
+    const r = processToolResponse(data)
+    assert.equal(r.ok, false)
+    assert.equal(r.errorType, 'no_tool_use')
+  })
+
+  test('regions가 2개만 — invalid_regions', () => {
+    const r = processToolResponse(fixtureToolUseResponse({ regions: fixtureRegions(2) }))
+    assert.equal(r.ok, false)
+    assert.equal(r.errorType, 'invalid_regions')
+  })
+
+  test('regions가 4개 — invalid_regions', () => {
+    const r = processToolResponse(fixtureToolUseResponse({ regions: fixtureRegions(4) }))
+    assert.equal(r.ok, false)
+    assert.equal(r.errorType, 'invalid_regions')
+  })
+
+  test('regions 누락 (undefined)', () => {
+    const r = processToolResponse(fixtureToolUseResponse({ regions: undefined }))
+    assert.equal(r.ok, false)
+    assert.equal(r.errorType, 'invalid_regions')
+  })
+
+  test('regions가 배열이 아님 (string)', () => {
+    const r = processToolResponse(fixtureToolUseResponse({ regions: 'oops' }))
+    assert.equal(r.ok, false)
+    assert.equal(r.errorType, 'invalid_regions')
+  })
+
+  test('null 입력 — 안전 처리', () => {
+    const r = processToolResponse(null)
+    assert.equal(r.ok, false)
+    assert.equal(r.errorType, 'no_tool_use')
+  })
+
+  test('undefined 입력 — 안전 처리', () => {
+    const r = processToolResponse(undefined)
+    assert.equal(r.ok, false)
+    assert.equal(r.errorType, 'no_tool_use')
+  })
+})
+
+describe('processToolResponse — toolName 인자', () => {
+  test('다른 toolName으로 호출 가능 (saju-confirm용)', () => {
+    const data = {
+      stop_reason: 'tool_use',
+      content: [{ type: 'tool_use', name: 'submit_saju_premium_report', input: { regions: fixtureRegions(3) } }],
+    }
+    const r = processToolResponse(data, 'submit_saju_premium_report')
+    assert.equal(r.ok, true)
+  })
+
+  test('toolName 불일치 시 거부', () => {
+    const data = {
+      stop_reason: 'tool_use',
+      content: [{ type: 'tool_use', name: 'submit_saju_report', input: { regions: fixtureRegions(3) } }],
+    }
+    const r = processToolResponse(data, 'submit_saju_premium_report')
+    assert.equal(r.ok, false)
+    assert.equal(r.errorType, 'no_tool_use')
+  })
+})
+
+// ───────────────────────────────────────────────────────────────
+// 3. SAJU_TOOL schema 자체 검증
+// ───────────────────────────────────────────────────────────────
+describe('SAJU_TOOL schema 무결성', () => {
+  const s = SAJU_TOOL.input_schema
+
+  test('tool name이 prompt에서 참조하는 이름과 일치', () => {
+    assert.equal(SAJU_TOOL.name, 'submit_saju_report')
+  })
+
+  test('top-level required에 핵심 필드 포함', () => {
+    for (const f of ['ilgan','plainSummary','saju','timing','regions','warning','summary','finalVerdict']) {
+      assert.ok(s.required.includes(f), `required에 ${f}`)
+    }
+  })
+
+  test('regions는 정확히 3개로 강제', () => {
+    assert.equal(s.properties.regions.minItems, 3)
+    assert.equal(s.properties.regions.maxItems, 3)
+  })
+
+  test('ilgan enum에 10천간 모두 존재', () => {
+    const ilganEnum = s.properties.ilgan.enum
+    assert.equal(ilganEnum.length, 10)
+    for (const e of ['甲木','乙木','丙火','丁火','戊土','己土','庚金','辛金','壬水','癸水']) {
+      assert.ok(ilganEnum.includes(e), `ilgan enum에 ${e}`)
+    }
+  })
+
+  test('yongshin enum에 5오행', () => {
+    const arr = s.properties.saju.properties.yongshin.enum
+    assert.deepEqual(arr.sort(), ['木','水','火','金','土'].sort())
+  })
+
+  test('score 범위 0-100', () => {
+    const item = s.properties.regions.items
+    assert.equal(item.properties.score.minimum, 0)
+    assert.equal(item.properties.score.maximum, 100)
+  })
+
+  test('scoreBreakdown 4개 항목 모두 0-25 범위', () => {
+    const sb = s.properties.regions.items.properties.scoreBreakdown.properties
+    for (const key of ['ohaengMatch','jimingOhaeng','landscape','lifeEnergy']) {
+      assert.equal(sb[key].properties.score.minimum, 0, `${key}.minimum`)
+      assert.equal(sb[key].properties.score.maximum, 25, `${key}.maximum`)
+    }
+  })
+})

--- a/api/__tests__/saju.test.js
+++ b/api/__tests__/saju.test.js
@@ -254,4 +254,16 @@ describe('SAJU_TOOL schema 무결성', () => {
       assert.equal(sb[key].properties.score.maximum, 25, `${key}.maximum`)
     }
   })
+
+  test('주요 string 필드에 maxLength — 응답 시간 단축용', () => {
+    const sb = s.properties.regions.items.properties.scoreBreakdown.properties
+    for (const key of ['ohaengMatch','jimingOhaeng','landscape','lifeEnergy']) {
+      assert.ok(sb[key].properties.reason.maxLength > 0, `scoreBreakdown.${key}.reason.maxLength`)
+      assert.ok(sb[key].properties.reason.maxLength <= 80, `scoreBreakdown.${key}.reason 너무 길지 않음`)
+    }
+    assert.ok(s.properties.regions.items.properties.whyThisGu.maxLength > 0, 'whyThisGu.maxLength')
+    assert.ok(s.properties.regions.items.properties.dailyLife.maxLength > 0, 'dailyLife.maxLength')
+    assert.ok(s.properties.plainSummary.maxLength > 0, 'plainSummary.maxLength')
+    assert.ok(s.properties.finalVerdict.maxLength > 0, 'finalVerdict.maxLength')
+  })
 })

--- a/api/saju-confirm.js
+++ b/api/saju-confirm.js
@@ -4,6 +4,7 @@ export const config = { maxDuration: 60, regions: ['icn1'] }
 import { readFileSync } from 'fs'
 import { join } from 'path'
 import { setCors } from './_utils.js'
+import { processToolResponse } from './saju.js'
 
 let aptCache = null
 function loadApts() {
@@ -25,26 +26,92 @@ function getAptSamples(gu) {
   }))
 }
 
-function sanitizeJson(str) {
-  let out = '', inStr = false, esc = false
-  for (const ch of str) {
-    if (esc)                   { out += ch; esc = false; continue }
-    if (ch === '\\' && inStr)  { out += ch; esc = true;  continue }
-    if (ch === '"')            { inStr = !inStr; out += ch; continue }
-    if (inStr && ch === '\n')  { out += '\\n'; continue }
-    if (inStr && ch === '\r')  { out += '\\r'; continue }
-    if (inStr && ch === '\t')  { out += '\\t'; continue }
-    out += ch
-  }
-  return out
-}
-
 const YONGSHIN_GU = {
   水: ['마포구', '용산구', '영등포구', '노원구', '도봉구'],
   木: ['성동구', '광진구', '동대문구', '중랑구', '강동구'],
   火: ['강남구', '서초구', '송파구', '동작구', '관악구'],
   金: ['강서구', '양천구', '구로구', '서대문구', '금천구'],
   土: ['중구', '종로구', '은평구', '성북구', '강북구'],
+}
+
+// ── 결제 사용자용 풍부 리포트 schema (saju.js의 SAJU_TOOL과 별개 — vsOther 추가) ─
+const PREMIUM_TOOL = {
+  name: 'submit_saju_premium_report',
+  description: '결제 사용자용 풍부한 사주 리포트. 모든 필드를 빠짐없이 채우세요.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      ilgan: {
+        type: 'string',
+        enum: ['甲木','乙木','丙火','丁火','戊土','己土','庚金','辛金','壬水','癸水'],
+        description: '일간 (천간 한자 + 오행)',
+      },
+      saju: {
+        type: 'object',
+        properties: {
+          ohaengDist:     { type: 'string' },
+          sinkang:        { type: 'string', enum: ['신강','신약','중화'] },
+          yongshin:       { type: 'string', enum: ['水','木','火','金','土'] },
+          yongShinReason: { type: 'string' },
+          daewon:         { type: 'string' },
+          sewon:          { type: 'string' },
+        },
+        required: ['ohaengDist','sinkang','yongshin','yongShinReason','daewon','sewon'],
+      },
+      timing: {
+        type: 'object',
+        properties: {
+          isGoodYear:  { type: 'boolean' },
+          timingScore: { type: 'integer', minimum: 0, maximum: 100 },
+          reason:      { type: 'string' },
+          bestMonths:  { type: 'string' },
+        },
+        required: ['isGoodYear','timingScore','reason','bestMonths'],
+      },
+      regions: {
+        type: 'array',
+        minItems: 3,
+        maxItems: 3,
+        description: '용신 오행 매핑에서 TOP 3 자치구. rank는 1·2·3, score 내림차순.',
+        items: {
+          type: 'object',
+          properties: {
+            gu:    { type: 'string' },
+            rank:  { type: 'integer', minimum: 1, maximum: 3 },
+            score: { type: 'integer', minimum: 0, maximum: 100 },
+            scoreBreakdown: {
+              type: 'object',
+              properties: {
+                ohaengMatch:  { type: 'object', properties: { score: { type: 'integer', minimum: 0, maximum: 25 }, reason: { type: 'string' } }, required: ['score','reason'] },
+                jimingOhaeng: { type: 'object', properties: { score: { type: 'integer', minimum: 0, maximum: 25 }, reason: { type: 'string' } }, required: ['score','reason'] },
+                landscape:    { type: 'object', properties: { score: { type: 'integer', minimum: 0, maximum: 25 }, reason: { type: 'string' } }, required: ['score','reason'] },
+                lifeEnergy:   { type: 'object', properties: { score: { type: 'integer', minimum: 0, maximum: 25 }, reason: { type: 'string' } }, required: ['score','reason'] },
+              },
+              required: ['ohaengMatch','jimingOhaeng','landscape','lifeEnergy'],
+            },
+            jiming:    { type: 'string' },
+            whyThisGu: { type: 'string' },
+            dailyLife: { type: 'string' },
+            vsOther:   { type: 'string', description: '다른 후보 구 대비 이 구의 우위' },
+          },
+          required: ['gu','rank','score','scoreBreakdown','jiming','whyThisGu','dailyLife','vsOther'],
+        },
+      },
+      regionComparison: { type: 'string' },
+      warning: {
+        type: 'object',
+        properties: {
+          year:   { type: 'string' },
+          reason: { type: 'string' },
+          action: { type: 'string' },
+        },
+        required: ['year','reason','action'],
+      },
+      summary:      { type: 'string' },
+      finalVerdict: { type: 'string' },
+    },
+    required: ['ilgan','saju','timing','regions','regionComparison','warning','summary','finalVerdict'],
+  },
 }
 
 export default async function handler(req, res) {
@@ -100,10 +167,21 @@ export default async function handler(req, res) {
 입력: ${year}년 ${month}월 ${day}일 ${hour ? hour + '시' : '시간 미상'} (${gender === 'female' ? '여성' : '남성'})
 현재: ${currentYear}년
 
-아래 JSON만 출력 (줄바꿈 없이):
-{"ilgan":"甲木","saju":{"ohaengDist":"木 과다 水 부족","sinkang":"신강","yongshin":"水","yongShinReason":"신강 甲木은 水로 설기해야 균형. 水 없으면 목기 과잉으로 고집·번아웃 표출","daewon":"癸巳 대운(2020-2030)","sewon":"丙午년 식신. 새 출발 에너지"},"timing":{"isGoodYear":true,"timingScore":88,"reason":"대운이 용신 보충하고 세운이 새 시작 에너지. 계약·정착 적기","bestMonths":"봄 3-4월 가을 9-10월"},"regions":[{"gu":"마포구","rank":1,"score":95,"scoreBreakdown":{"ohaengMatch":{"score":24,"reason":"한강이 마포 남쪽을 따라 흘러 水 기운을 일상에서 공급. 甲木의 과잉 목기가 한강으로 자연스럽게 설기됨"},"jimingOhaeng":{"score":23,"reason":"麻浦의 浦는 水변 한자. 지명부터 水 오행이 담겨 땅 기운과 용신이 일치"},"landscape":{"score":24,"reason":"한강 남쪽, 공덕·아현 언덕 북쪽으로 배산임수 지형. 木 기운 언덕과 水 기운 한강이 甲木에게 자연 순환 구조를 만들어줌"},"lifeEnergy":{"score":24,"reason":"공덕역 4·5·6호선·공항철도 교통허브가 뻗어나가는 甲木 진취성과 맞음. 홍대·합정 상권 에너지가 일상 동력이 됨"}},"jiming":"麻浦(마포) — 浦자에 水변, 한강 포구의 물기운 담은 땅","whyThisGu":"甲木에게 Water는 자식 오행이자 에너지 순환 통로. 목기가 과잉되면 고집과 번아웃으로 표출되는데 한강이 옆에 있으면 그 기운이 자연스럽게 흘러내려 해소됨. 지명과 지형, 교통이 모두 이 사주와 맞아 떨어지는 최적의 동네","dailyLife":"퇴근 후 한강 산책 30분이 이 사주 최고의 에너지 해소법. 공덕역에서 강남·여의도·홍대 어디든 한 번에","vsOther":"한강+지명오행+배산임수+교통 4박자 충족. 용산은 水 좋지만 가격 부담, 영등포는 과수기 위험"},{"gu":"용산구","rank":2,"score":85,"scoreBreakdown":{"ohaengMatch":{"score":22,"reason":"한남·이촌이 한강에 직접 접해 水 에너지 충분. 마포보다 한강 접근 동네 비율 낮음"},"jimingOhaeng":{"score":19,"reason":"龍山의 龍은 Water 기운 동물로 간접 연결. 山 지명이라 木 기운도 있어 甲木과 공명하나 직접 오행 일치는 약함"},"landscape":{"score":23,"reason":"한강 남쪽, 남산 북쪽으로 전형적 배산임수. 남산 木이 甲木을 돕고 한강 Water가 용신 충족해 서울 풍수 균형 최우수"},"lifeEnergy":{"score":21,"reason":"한남·이태원 다국적 분위기가 甲木 진취성과 맞음. 상업·업무 기능이 강해 뿌리 내리는 환경은 마포보다 아쉬움"}},"jiming":"龍山(용산) — 용이 사는 산, 한강변 배산임수의 땅","whyThisGu":"남산 木과 한강 Water가 동시에 있어 甲木에게 두 에너지를 모두 공급받는 드문 지형. 서울 배산임수 최우수 구이나 가격 부담이 큼","dailyLife":"이촌한강공원 수기 충전 + 남산 산책 木 기운 보완 가능. 단 마포 대비 가격 부담 크고 교통 허브 기능 낮음","vsOther":"지형은 마포 동급이나 가격 부담·교통 허브 약세로 2순위"},{"gu":"영등포구","rank":3,"score":76,"scoreBreakdown":{"ohaengMatch":{"score":22,"reason":"여의도가 한강으로 둘러싸인 섬이라 Water 기운 최강. 단 과수기로 木이 익을 위험 있음"},"jimingOhaeng":{"score":15,"reason":"永登浦에는 Water 오행 한자 없음. 지명 오행 근거 세 곳 중 가장 약함"},"landscape":{"score":20,"reason":"여의도 한강 기운 좋지만 콘크리트 금융·업무 지형이 강해 자연 풍수 에너지 순도 낮음"},"lifeEnergy":{"score":19,"reason":"금융·방송 업무 에너지가 강해 퇴근 후에도 긴장 지속. 주거 안정 에너지보다 출력 에너지가 강한 동네"}},"jiming":"永登浦(영등포) — 여의도는 Water의 섬이나 지명 오행 근거 약함","whyThisGu":"Water 기운은 세 곳 중 최강이나 사방이 물이라 과수기로 木이 익을 수 있음. 업무 중심 지형이 장기 주거에 피로 누적","dailyLife":"여의도한강공원 접근은 좋지만 금융·업무 중심 환경이 퇴근 후에도 에너지 소모. 뿌리 내리는 안정이 부족","vsOther":"Water 최강이나 과수기 위험+지명 약점+주거 에너지 낮음으로 3순위"}],"regionComparison":"마포는 4박자 균형. 용산은 배산임수 최우수나 가격 부담. 영등포는 Water 강하나 과잉+지명 약점","warning":{"year":"2028년","reason":"삼형살 에너지 활성. 예상치 못한 변동 주의","action":"2028년 전 주거 안정. 해당 연도 대형 결정·추가 대출 자제"},"summary":"甲木 일간에 Water 용신 — 한강 옆에서 살면 목기가 매일 순환돼요","finalVerdict":"사주 흐름상 지금이 정착 적기. 마포구 한강변이 지명·지형·생활 모두에서 맞아 장기적으로 안정됩니다"}`
+[용신 오행별 서울 구 매핑 — 반드시 이 목록에서만 선택]
+水 용신: 마포구·용산구·영등포구·노원구·도봉구
+木 용신: 성동구·광진구·동대문구·중랑구·강동구
+火 용신: 강남구·서초구·송파구·동작구·관악구
+金 용신: 강서구·양천구·구로구·서대문구·금천구
+土 용신: 중구·종로구·은평구·성북구·강북구
 
-  // 2. Claude 사주 분석
+[분석 지시]
+- 만세력으로 사주 4주 8자를 정확히 산출한 뒤 신강/신약과 용신을 판단하세요.
+- 용신 오행 매핑에서 TOP 3 구를 선정하세요. 점수 차이 근거를 지명 오행·지형·생활 에너지 세 가지로 구체적으로 설명하고, vsOther에 다른 후보 대비 우위를 작성하세요.
+- scoreBreakdown 4개 항목 점수 합이 score와 일치하도록 분배하세요.
+
+분석 결과는 반드시 submit_saju_premium_report 도구로 제출하세요.`
+
+  // 2. Claude 사주 분석 (tool use)
   const ctrl = new AbortController()
   const tid  = setTimeout(() => ctrl.abort(), 40000)
 
@@ -119,7 +197,9 @@ export default async function handler(req, res) {
       },
       body: JSON.stringify({
         model: 'claude-haiku-4-5-20251001',
-        max_tokens: 3000,
+        max_tokens: 4096,
+        tools: [PREMIUM_TOOL],
+        tool_choice: { type: 'tool', name: PREMIUM_TOOL.name },
         messages: [{ role: 'user', content: prompt }],
       }),
     })
@@ -129,23 +209,24 @@ export default async function handler(req, res) {
   }
   clearTimeout(tid)
 
-  const aiData = await aiResp.json()
-  const raw    = aiData?.content?.[0]?.text || ''
-  const start  = raw.indexOf('{')
-  const end    = raw.lastIndexOf('}')
-  if (start === -1 || end === -1) return res.status(500).json({ error: '분석 결과 파싱 실패' })
-
-  let result
-  try {
-    result = JSON.parse(sanitizeJson(raw.slice(start, end + 1)))
-  } catch {
-    return res.status(500).json({ error: 'JSON 파싱 실패 — 다시 시도해주세요' })
+  if (!aiResp.ok) {
+    const errBody = await aiResp.text().catch(() => '')
+    console.error(`[saju-confirm] http_${aiResp.status} body=${errBody.slice(0, 200)}`)
+    return res.status(500).json({ error: '분석 요청 실패 — 다시 시도해주세요' })
   }
 
+  const aiData = await aiResp.json()
+  const r = processToolResponse(aiData, PREMIUM_TOOL.name)
+  if (!r.ok) {
+    console.error(`[saju-confirm] ${r.errorType} stop=${aiData?.stop_reason} tokens_out=${aiData?.usage?.output_tokens ?? '?'}`)
+    return res.status(500).json({ error: '분석 결과 검증 실패 — 다시 시도해주세요', errorType: r.errorType })
+  }
+  const result = r.result
+
   if (result.regions) {
-    result.regions = result.regions.map(r => ({
-      ...r,
-      apts: r.apts?.length > 0 ? r.apts : (aptData[r.gu] || []),
+    result.regions = result.regions.map(reg => ({
+      ...reg,
+      apts: reg.apts?.length > 0 ? reg.apts : (aptData[reg.gu] || []),
     }))
   }
 

--- a/api/saju.js
+++ b/api/saju.js
@@ -107,9 +107,15 @@ function getAptSamples(gu, count = 2) {
 }
 
 // ── Anthropic Tool Schema — 모델이 반드시 이 구조로 응답 ─────
+//   모든 string 필드에 maxLength 강제 → 출력 토큰 ↓ → 응답 시간 ↓
+//   (Anthropic Haiku tool-use가 28s 안에 안 끝나는 케이스 회피)
+const REASON_MAX = 60     // scoreBreakdown 4축 reason
+const SHORT_MAX  = 80     // jiming, dailyLife, summary 등
+const MED_MAX    = 150    // whyThisGu, regionComparison, finalVerdict
+
 export const SAJU_TOOL = {
   name: 'submit_saju_report',
-  description: '사주 분석 결과를 정해진 구조로 제출합니다. 모든 필드를 빠짐없이 채우세요.',
+  description: '사주 분석 결과를 정해진 구조로 제출합니다. 모든 필드는 정해진 maxLength 안에서 간결하게 작성하세요.',
   input_schema: {
     type: 'object',
     properties: {
@@ -120,17 +126,18 @@ export const SAJU_TOOL = {
       },
       plainSummary: {
         type: 'string',
+        maxLength: 100,
         description: '사주 모르는 일반인용 2~3문장. 한자/전문용어(일간·용신·신강·신약·오행·설기 등) 절대 금지. 형식: "당신은 [성격] 사주예요. [어떤 동네]가 잘 맞아요."',
       },
       saju: {
         type: 'object',
         properties: {
-          ohaengDist:     { type: 'string', description: '오행 분포 한 줄 (예: "火 과다 木 약")' },
+          ohaengDist:     { type: 'string', maxLength: 50, description: '오행 분포 한 줄 (예: "火 과다 木 약")' },
           sinkang:        { type: 'string', enum: ['신강','신약','중화'] },
           yongshin:       { type: 'string', enum: ['水','木','火','金','土'] },
-          yongShinReason: { type: 'string' },
-          daewon:         { type: 'string', description: '현재 대운 (예: "庚申 대운(2022-2032)")' },
-          sewon:          { type: 'string', description: '올해 세운 한 줄 (예: "丙午년 비겁")' },
+          yongShinReason: { type: 'string', maxLength: 80, description: '용신 선정 이유 (한 문장)' },
+          daewon:         { type: 'string', maxLength: 50, description: '현재 대운 (예: "庚申 대운(2022-2032)")' },
+          sewon:          { type: 'string', maxLength: 50, description: '올해 세운 한 줄 (예: "丙午년 비겁")' },
         },
         required: ['ohaengDist','sinkang','yongshin','yongShinReason','daewon','sewon'],
       },
@@ -139,8 +146,8 @@ export const SAJU_TOOL = {
         properties: {
           isGoodYear:  { type: 'boolean' },
           timingScore: { type: 'integer', minimum: 0, maximum: 100 },
-          reason:      { type: 'string' },
-          bestMonths:  { type: 'string' },
+          reason:      { type: 'string', maxLength: 100 },
+          bestMonths:  { type: 'string', maxLength: 50 },
         },
         required: ['isGoodYear','timingScore','reason','bestMonths'],
       },
@@ -152,38 +159,38 @@ export const SAJU_TOOL = {
         items: {
           type: 'object',
           properties: {
-            gu:    { type: 'string', description: '서울 자치구 이름 (예: "마포구")' },
+            gu:    { type: 'string', maxLength: 10, description: '서울 자치구 이름 (예: "마포구")' },
             rank:  { type: 'integer', minimum: 1, maximum: 3 },
             score: { type: 'integer', minimum: 0, maximum: 100 },
             scoreBreakdown: {
               type: 'object',
               properties: {
-                ohaengMatch:   { type: 'object', properties: { score: { type: 'integer', minimum: 0, maximum: 25 }, reason: { type: 'string' } }, required: ['score','reason'] },
-                jimingOhaeng:  { type: 'object', properties: { score: { type: 'integer', minimum: 0, maximum: 25 }, reason: { type: 'string' } }, required: ['score','reason'] },
-                landscape:     { type: 'object', properties: { score: { type: 'integer', minimum: 0, maximum: 25 }, reason: { type: 'string' } }, required: ['score','reason'] },
-                lifeEnergy:    { type: 'object', properties: { score: { type: 'integer', minimum: 0, maximum: 25 }, reason: { type: 'string' } }, required: ['score','reason'] },
+                ohaengMatch:   { type: 'object', properties: { score: { type: 'integer', minimum: 0, maximum: 25 }, reason: { type: 'string', maxLength: REASON_MAX } }, required: ['score','reason'] },
+                jimingOhaeng:  { type: 'object', properties: { score: { type: 'integer', minimum: 0, maximum: 25 }, reason: { type: 'string', maxLength: REASON_MAX } }, required: ['score','reason'] },
+                landscape:     { type: 'object', properties: { score: { type: 'integer', minimum: 0, maximum: 25 }, reason: { type: 'string', maxLength: REASON_MAX } }, required: ['score','reason'] },
+                lifeEnergy:    { type: 'object', properties: { score: { type: 'integer', minimum: 0, maximum: 25 }, reason: { type: 'string', maxLength: REASON_MAX } }, required: ['score','reason'] },
               },
               required: ['ohaengMatch','jimingOhaeng','landscape','lifeEnergy'],
             },
-            jiming:    { type: 'string', description: '지명 풀이 (예: "麻浦(마포) — 浦자에 水변, 한강 포구")' },
-            whyThisGu: { type: 'string', description: '이 구를 추천하는 이유 (사주와 연결, 구체적으로)' },
-            dailyLife: { type: 'string', description: '일상 생활 에너지 한 줄' },
+            jiming:    { type: 'string', maxLength: SHORT_MAX, description: '지명 풀이 (예: "麻浦(마포) — 浦자에 水변, 한강 포구")' },
+            whyThisGu: { type: 'string', maxLength: MED_MAX,   description: '이 구를 추천하는 이유 (사주와 연결, 1~2문장)' },
+            dailyLife: { type: 'string', maxLength: SHORT_MAX, description: '일상 생활 에너지 한 줄' },
           },
           required: ['gu','rank','score','scoreBreakdown','jiming','whyThisGu','dailyLife'],
         },
       },
-      regionComparison: { type: 'string', description: '3개 구의 비교 한 줄' },
+      regionComparison: { type: 'string', maxLength: MED_MAX,   description: '3개 구의 비교 한 줄' },
       warning: {
         type: 'object',
         properties: {
-          year:   { type: 'string', description: '주의 세운 연도' },
-          reason: { type: 'string' },
-          action: { type: 'string' },
+          year:   { type: 'string', maxLength: 20,  description: '주의 세운 연도' },
+          reason: { type: 'string', maxLength: 100 },
+          action: { type: 'string', maxLength: 100 },
         },
         required: ['year','reason','action'],
       },
-      summary:      { type: 'string', description: '한 줄 요약' },
-      finalVerdict: { type: 'string', description: '최종 판단 (1~2문장)' },
+      summary:      { type: 'string', maxLength: SHORT_MAX, description: '한 줄 요약' },
+      finalVerdict: { type: 'string', maxLength: MED_MAX,   description: '최종 판단 (1~2문장)' },
     },
     required: ['ilgan','plainSummary','saju','timing','regions','regionComparison','warning','summary','finalVerdict'],
   },
@@ -255,18 +262,28 @@ ${pillarsInfo}
 - 오행 분포와 8자를 꼼꼼히 분석해 신강/신약과 용신을 정확히 판단하세요.
 - 용신 오행 매핑에서 TOP 3 구를 선정하세요. 단, 아래 조건을 지키세요:
   · 사주마다 다른 구가 나와야 합니다 (같은 오행 내에서도 순위는 8자 특성에 따라 달라집니다)
-  · 점수 차이의 근거를 지명 오행·지형·생활 에너지 세 가지로 구체적으로 설명하세요
+  · 점수 차이의 근거를 지명 오행·지형·생활 에너지 세 가지로 설명하세요
   · scoreBreakdown 4개 항목 점수 합이 score와 일치하도록 분배하세요
+
+[글자수 제한 — 응답 시간 단축]
+- 각 reason은 한 문장 60자 이내로 압축하세요
+- whyThisGu / regionComparison / finalVerdict 는 1~2문장 150자 이내
+- 핵심만 담고 부연·중복 표현은 제거하세요
 
 분석 결과는 반드시 submit_saju_report 도구로 제출하세요.`
 
   // ── 진단 로깅 — 모든 시도 결과 추적 ───────────────────────
   const diag = { startedAt: Date.now(), attempts: [] }
 
+  // 비대칭 timeout: 첫 시도 cold start + 풀 응답 흡수, 재시도는 transient 회복용
+  // 38s + 1s wait + 18s = 57s (Vercel 60s 한도 안)
+  const TIMEOUTS = [38000, 18000]
+
   async function callAI(attempt) {
     const t0 = Date.now()
     const ctrl = new AbortController()
-    const tid  = setTimeout(() => ctrl.abort(), 28000)
+    const timeoutMs = TIMEOUTS[attempt] || 18000
+    const tid  = setTimeout(() => ctrl.abort(), timeoutMs)
     try {
       const resp = await fetch('https://api.anthropic.com/v1/messages', {
         method: 'POST',
@@ -278,7 +295,7 @@ ${pillarsInfo}
         },
         body: JSON.stringify({
           model: 'claude-haiku-4-5-20251001',
-          max_tokens: 4096,
+          max_tokens: 3000,
           tools: [SAJU_TOOL],
           tool_choice: { type: 'tool', name: SAJU_TOOL.name },
           messages: [{ role: 'user', content: prompt }],
@@ -309,8 +326,8 @@ ${pillarsInfo}
     } catch (e) {
       clearTimeout(tid)
       const dur = Date.now() - t0
-      // AbortError = 28s 타임아웃 / TypeError = 네트워크 / 기타 = 알 수 없음
-      const errorType = e?.name === 'AbortError' ? 'abort_28s'
+      // AbortError = 비대칭 timeout / TypeError = 네트워크 / 기타 = 알 수 없음
+      const errorType = e?.name === 'AbortError' ? `abort_${Math.round(timeoutMs/1000)}s`
                       : e?.name === 'TypeError'  ? 'network'
                       : `exception_${e?.name || 'unknown'}`
       console.error(`[saju] attempt=${attempt} ${errorType} dur=${dur}ms msg=${e?.message}`)
@@ -320,7 +337,7 @@ ${pillarsInfo}
   }
 
   try {
-    // 최대 2번 시도 (Vercel 60s · 프론트 55s · 28s × 2 + 1s 대기 = 57s)
+    // 최대 2번 시도 (Vercel 60s · 프론트 55s · 비대칭 38s+18s + 1s 대기 = 57s)
     let result = null
     for (let attempt = 0; attempt < 2; attempt++) {
       if (attempt > 0) await new Promise(r => setTimeout(r, 1000))

--- a/api/saju.js
+++ b/api/saju.js
@@ -266,7 +266,7 @@ ${pillarsInfo}
   async function callAI(attempt) {
     const t0 = Date.now()
     const ctrl = new AbortController()
-    const tid  = setTimeout(() => ctrl.abort(), 25000)
+    const tid  = setTimeout(() => ctrl.abort(), 28000)
     try {
       const resp = await fetch('https://api.anthropic.com/v1/messages', {
         method: 'POST',
@@ -309,8 +309,8 @@ ${pillarsInfo}
     } catch (e) {
       clearTimeout(tid)
       const dur = Date.now() - t0
-      // AbortError = 25s 타임아웃 / TypeError = 네트워크 / 기타 = 알 수 없음
-      const errorType = e?.name === 'AbortError' ? 'abort_25s'
+      // AbortError = 28s 타임아웃 / TypeError = 네트워크 / 기타 = 알 수 없음
+      const errorType = e?.name === 'AbortError' ? 'abort_28s'
                       : e?.name === 'TypeError'  ? 'network'
                       : `exception_${e?.name || 'unknown'}`
       console.error(`[saju] attempt=${attempt} ${errorType} dur=${dur}ms msg=${e?.message}`)
@@ -320,7 +320,7 @@ ${pillarsInfo}
   }
 
   try {
-    // 최대 2번 시도 (Vercel 60s · 프론트 55s · 25s × 2 + 1s 대기)
+    // 최대 2번 시도 (Vercel 60s · 프론트 55s · 28s × 2 + 1s 대기 = 57s)
     let result = null
     for (let attempt = 0; attempt < 2; attempt++) {
       if (attempt > 0) await new Promise(r => setTimeout(r, 1000))

--- a/api/saju.js
+++ b/api/saju.js
@@ -63,7 +63,7 @@ function hanja(stem, branch) {
   return HEAVENLY_STEMS_H[HEAVENLY_STEMS.indexOf(stem)] + EARTHLY_BRANCHES_H[EARTHLY_BRANCHES.indexOf(branch)]
 }
 
-function calcFourPillars(year, month, day, si) {
+export function calcFourPillars(year, month, day, si) {
   const yr = getYearPillar(year)
   const mo = getMonthPillar(year, month, day)
   const da = getDayPillar(year, month, day)
@@ -106,18 +106,103 @@ function getAptSamples(gu, count = 2) {
   }))
 }
 
-function sanitizeJson(str) {
-  let out = '', inStr = false, esc = false
-  for (const ch of str) {
-    if (esc)                   { out += ch; esc = false; continue }
-    if (ch === '\\' && inStr)  { out += ch; esc = true;  continue }
-    if (ch === '"')            { inStr = !inStr; out += ch; continue }
-    if (inStr && ch === '\n')  { out += '\\n'; continue }
-    if (inStr && ch === '\r')  { out += '\\r'; continue }
-    if (inStr && ch === '\t')  { out += '\\t'; continue }
-    out += ch
+// ── Anthropic Tool Schema — 모델이 반드시 이 구조로 응답 ─────
+export const SAJU_TOOL = {
+  name: 'submit_saju_report',
+  description: '사주 분석 결과를 정해진 구조로 제출합니다. 모든 필드를 빠짐없이 채우세요.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      ilgan: {
+        type: 'string',
+        enum: ['甲木','乙木','丙火','丁火','戊土','己土','庚金','辛金','壬水','癸水'],
+        description: '일간 (천간 한자 + 오행). 만세력 일주(日柱)의 천간을 그대로 사용.',
+      },
+      plainSummary: {
+        type: 'string',
+        description: '사주 모르는 일반인용 2~3문장. 한자/전문용어(일간·용신·신강·신약·오행·설기 등) 절대 금지. 형식: "당신은 [성격] 사주예요. [어떤 동네]가 잘 맞아요."',
+      },
+      saju: {
+        type: 'object',
+        properties: {
+          ohaengDist:     { type: 'string', description: '오행 분포 한 줄 (예: "火 과다 木 약")' },
+          sinkang:        { type: 'string', enum: ['신강','신약','중화'] },
+          yongshin:       { type: 'string', enum: ['水','木','火','金','土'] },
+          yongShinReason: { type: 'string' },
+          daewon:         { type: 'string', description: '현재 대운 (예: "庚申 대운(2022-2032)")' },
+          sewon:          { type: 'string', description: '올해 세운 한 줄 (예: "丙午년 비겁")' },
+        },
+        required: ['ohaengDist','sinkang','yongshin','yongShinReason','daewon','sewon'],
+      },
+      timing: {
+        type: 'object',
+        properties: {
+          isGoodYear:  { type: 'boolean' },
+          timingScore: { type: 'integer', minimum: 0, maximum: 100 },
+          reason:      { type: 'string' },
+          bestMonths:  { type: 'string' },
+        },
+        required: ['isGoodYear','timingScore','reason','bestMonths'],
+      },
+      regions: {
+        type: 'array',
+        minItems: 3,
+        maxItems: 3,
+        description: '용신 오행 매핑에서 TOP 3 자치구. rank는 1·2·3, score 내림차순.',
+        items: {
+          type: 'object',
+          properties: {
+            gu:    { type: 'string', description: '서울 자치구 이름 (예: "마포구")' },
+            rank:  { type: 'integer', minimum: 1, maximum: 3 },
+            score: { type: 'integer', minimum: 0, maximum: 100 },
+            scoreBreakdown: {
+              type: 'object',
+              properties: {
+                ohaengMatch:   { type: 'object', properties: { score: { type: 'integer', minimum: 0, maximum: 25 }, reason: { type: 'string' } }, required: ['score','reason'] },
+                jimingOhaeng:  { type: 'object', properties: { score: { type: 'integer', minimum: 0, maximum: 25 }, reason: { type: 'string' } }, required: ['score','reason'] },
+                landscape:     { type: 'object', properties: { score: { type: 'integer', minimum: 0, maximum: 25 }, reason: { type: 'string' } }, required: ['score','reason'] },
+                lifeEnergy:    { type: 'object', properties: { score: { type: 'integer', minimum: 0, maximum: 25 }, reason: { type: 'string' } }, required: ['score','reason'] },
+              },
+              required: ['ohaengMatch','jimingOhaeng','landscape','lifeEnergy'],
+            },
+            jiming:    { type: 'string', description: '지명 풀이 (예: "麻浦(마포) — 浦자에 水변, 한강 포구")' },
+            whyThisGu: { type: 'string', description: '이 구를 추천하는 이유 (사주와 연결, 구체적으로)' },
+            dailyLife: { type: 'string', description: '일상 생활 에너지 한 줄' },
+          },
+          required: ['gu','rank','score','scoreBreakdown','jiming','whyThisGu','dailyLife'],
+        },
+      },
+      regionComparison: { type: 'string', description: '3개 구의 비교 한 줄' },
+      warning: {
+        type: 'object',
+        properties: {
+          year:   { type: 'string', description: '주의 세운 연도' },
+          reason: { type: 'string' },
+          action: { type: 'string' },
+        },
+        required: ['year','reason','action'],
+      },
+      summary:      { type: 'string', description: '한 줄 요약' },
+      finalVerdict: { type: 'string', description: '최종 판단 (1~2문장)' },
+    },
+    required: ['ilgan','plainSummary','saju','timing','regions','regionComparison','warning','summary','finalVerdict'],
+  },
+}
+
+// ── tool_use 응답 검증 — 응답에서 tool 블록 추출 + regions 후처리 검사 ─
+export function processToolResponse(data, toolName = SAJU_TOOL.name) {
+  if (data?.stop_reason === 'max_tokens') return { ok: false, errorType: 'max_tokens' }
+  const block = Array.isArray(data?.content)
+    ? data.content.find(c => c?.type === 'tool_use' && c?.name === toolName)
+    : null
+  if (!block || !block.input || typeof block.input !== 'object') {
+    return { ok: false, errorType: 'no_tool_use' }
   }
-  return out
+  const result = block.input
+  if (!Array.isArray(result.regions) || result.regions.length !== 3) {
+    return { ok: false, errorType: 'invalid_regions' }
+  }
+  return { ok: true, result }
 }
 
 export default async function handler(req, res) {
@@ -158,7 +243,7 @@ ${pillarsInfo}
 성별: ${gender === 'female' ? '여성' : '남성'}
 현재: ${currentYear}년
 
-[용신 오행별 서울 구 매핑 — 반드시 이 목록에서 선택]
+[용신 오행별 서울 구 매핑 — 반드시 이 목록에서만 선택]
 水 용신: 마포구·용산구·영등포구·노원구·도봉구
 木 용신: 성동구·광진구·동대문구·중랑구·강동구
 火 용신: 강남구·서초구·송파구·동작구·관악구
@@ -170,26 +255,18 @@ ${pillarsInfo}
 - 오행 분포와 8자를 꼼꼼히 분석해 신강/신약과 용신을 정확히 판단하세요.
 - 용신 오행 매핑에서 TOP 3 구를 선정하세요. 단, 아래 조건을 지키세요:
   · 사주마다 다른 구가 나와야 합니다 (같은 오행 내에서도 순위는 8자 특성에 따라 달라집니다)
-  · 점수 차이가 나는 이유를 지명 오행·지형·생활 에너지 세 가지로 구체적으로 설명하세요
+  · 점수 차이의 근거를 지명 오행·지형·생활 에너지 세 가지로 구체적으로 설명하세요
+  · scoreBreakdown 4개 항목 점수 합이 score와 일치하도록 분배하세요
 
-[plainSummary 작성 규칙 — 매우 중요]
-- 사주 모르는 일반인을 위한 2~3문장 요약
-- "일간/용신/신강/신약/오행/설기" 같은 한자·전문용어 절대 사용 금지
-- "활동적이다 / 차분하다 / 열정적이다 / 안정적이다" 같은 일상 언어로
-- 형식: "당신은 [성격] 사주예요. [어떤 동네]가 잘 맞아요."
-- 예시: "당신은 에너지가 강하고 추진력이 좋은 사주예요. 차분하고 정돈된 동네에서 균형이 맞춰져요."
+분석 결과는 반드시 submit_saju_report 도구로 제출하세요.`
 
-아래 JSON만 출력 (줄바꿈 없이):
-{"ilgan":"丙火","plainSummary":"당신은 에너지 강하고 열정적인 사주예요. 차분하고 정돈된 동네에서 균형이 맞춰져요.","saju":{"ohaengDist":"火 과다 木 약","sinkang":"신강","yongshin":"金","yongShinReason":"신강 丙火는 金으로 설기해야 균형","daewon":"庚申 대운(2022-2032)","sewon":"丙午년 비겁"},"timing":{"isGoodYear":false,"timingScore":62,"reason":"비겁운으로 경쟁·충돌 주의","bestMonths":"가을 9-10월"},"regions":[{"gu":"강서구","rank":1,"score":91,"scoreBreakdown":{"ohaengMatch":{"score":25,"reason":"江西의 西는 金 방위, 서쪽 기운"},"jimingOhaeng":{"score":22,"reason":"강서의 西자 金 오행 직결"},"landscape":{"score":22,"reason":"한강 北岸 평지, 金 기운 안정"},"lifeEnergy":{"score":22,"reason":"김포공항·마곡 신산업 金 에너지"}},"jiming":"江西(강서) — 西자에 金 방위","whyThisGu":"이유","dailyLife":"일상 에너지"},{"gu":"양천구","rank":2,"score":83,"scoreBreakdown":{"ohaengMatch":{"score":22,"reason":"서쪽 위치, 金 방위"},"jimingOhaeng":{"score":18,"reason":"陽川, 직접 금 오행 약함"},"landscape":{"score":22,"reason":"목동 정주 에너지 안정"},"lifeEnergy":{"score":21,"reason":"학군·가족 중심 생활"}},"jiming":"陽川(양천) — 서쪽 금 방위 지역","whyThisGu":"이유","dailyLife":"일상"},{"gu":"서대문구","rank":3,"score":74,"scoreBreakdown":{"ohaengMatch":{"score":20,"reason":"서쪽 金 방위 약하게 해당"},"jimingOhaeng":{"score":16,"reason":"西大門의 西자 金 방위"},"landscape":{"score":19,"reason":"인왕산 金 기운, 북쪽 지형"},"lifeEnergy":{"score":19,"reason":"대학가 지식 에너지"}},"jiming":"西大門(서대문) — 西자 金 방위","whyThisGu":"이유","dailyLife":"일상"}],"regionComparison":"비교","warning":{"year":"2029년","reason":"주의","action":"대비"},"summary":"한 줄 요약","finalVerdict":"최종 판단"}`
-
-  // ── 진단 로깅용 — 모든 시도의 결과를 추적 ─────────────────
-  const diag = { startedAt: Date.now(), attempts: [], finalErrorType: null }
+  // ── 진단 로깅 — 모든 시도 결과 추적 ───────────────────────
+  const diag = { startedAt: Date.now(), attempts: [] }
 
   async function callAI(attempt) {
     const t0 = Date.now()
     const ctrl = new AbortController()
     const tid  = setTimeout(() => ctrl.abort(), 25000)
-    let httpStatus = null
     try {
       const resp = await fetch('https://api.anthropic.com/v1/messages', {
         method: 'POST',
@@ -202,14 +279,12 @@ ${pillarsInfo}
         body: JSON.stringify({
           model: 'claude-haiku-4-5-20251001',
           max_tokens: 4096,
-          messages: [
-            { role: 'user', content: prompt },
-            { role: 'assistant', content: '{"ilgan":"' },
-          ],
+          tools: [SAJU_TOOL],
+          tool_choice: { type: 'tool', name: SAJU_TOOL.name },
+          messages: [{ role: 'user', content: prompt }],
         }),
       })
       clearTimeout(tid)
-      httpStatus = resp.status
       const dur = Date.now() - t0
 
       if (!resp.ok) {
@@ -221,25 +296,16 @@ ${pillarsInfo}
       }
 
       const data = await resp.json()
-      const raw  = '{"ilgan":"' + (data?.content?.[0]?.text || '')
-
-      if (data?.stop_reason === 'max_tokens') {
-        const errorType = 'max_tokens'
-        console.error(`[saju] attempt=${attempt} ${errorType} dur=${dur}ms — output truncated`)
-        diag.attempts.push({ attempt, errorType, durationMs: dur })
-        return { ok: false, errorType }
+      const tokens = data?.usage?.output_tokens ?? '?'
+      const r = processToolResponse(data)
+      if (!r.ok) {
+        console.error(`[saju] attempt=${attempt} ${r.errorType} dur=${dur}ms stop=${data?.stop_reason} tokens_out=${tokens}`)
+        diag.attempts.push({ attempt, errorType: r.errorType, durationMs: dur })
+        return r
       }
-
-      if (!data?.content?.[0]?.text) {
-        const errorType = 'empty_response'
-        console.error(`[saju] attempt=${attempt} ${errorType} dur=${dur}ms stop=${data?.stop_reason}`)
-        diag.attempts.push({ attempt, errorType, durationMs: dur })
-        return { ok: false, errorType }
-      }
-
-      console.log(`[saju] attempt=${attempt} ok dur=${dur}ms tokens_out=${data?.usage?.output_tokens || '?'}`)
+      console.log(`[saju] attempt=${attempt} ok dur=${dur}ms tokens_out=${tokens}`)
       diag.attempts.push({ attempt, ok: true, durationMs: dur })
-      return { ok: true, raw }
+      return r
     } catch (e) {
       clearTimeout(tid)
       const dur = Date.now() - t0
@@ -254,45 +320,21 @@ ${pillarsInfo}
   }
 
   try {
-    // 최대 2번 시도 — JSON 파싱 성공할 때까지 (Vercel 60s · 프론트 55s 한도 안에 맞춤)
+    // 최대 2번 시도 (Vercel 60s · 프론트 55s · 25s × 2 + 1s 대기)
     let result = null
-    let parseFails = 0
     for (let attempt = 0; attempt < 2; attempt++) {
-      // 재시도 전 1초 대기 — Anthropic 일시 부하·rate limit 회피
       if (attempt > 0) await new Promise(r => setTimeout(r, 1000))
-
       const r = await callAI(attempt)
-      if (!r.ok || !r.raw || !r.raw.includes('{')) continue
-
-      const start = r.raw.indexOf('{')
-      const end   = r.raw.lastIndexOf('}')
-      if (start === -1 || end === -1) {
-        parseFails++
-        diag.attempts[diag.attempts.length - 1].parseError = 'no_brace'
-        continue
-      }
-
-      try {
-        result = JSON.parse(sanitizeJson(r.raw.slice(start, end + 1)))
-        break
-      } catch (e) {
-        parseFails++
-        const lastAttempt = diag.attempts[diag.attempts.length - 1]
-        lastAttempt.parseError = 'json_parse'
-        lastAttempt.parseErrorMsg = e?.message?.slice(0, 100)
-        console.error(`[saju] attempt=${attempt} parse_fail msg=${e?.message?.slice(0, 100)}`)
-        continue
-      }
+      if (r.ok) { result = r.result; break }
     }
 
     if (!result) {
-      // 최종 실패 — 가장 흔한 errorType 추출 + 전체 진단 로깅
       const lastAttempt = diag.attempts[diag.attempts.length - 1] || {}
-      const finalErrorType = lastAttempt.parseError || lastAttempt.errorType || 'unknown'
+      const finalErrorType = lastAttempt.errorType || 'unknown'
       const totalMs = Date.now() - diag.startedAt
-      console.error(`[saju] FAIL total=${totalMs}ms attempts=${diag.attempts.length} parseFails=${parseFails} finalErrorType=${finalErrorType}`, JSON.stringify(diag.attempts))
+      console.error(`[saju] FAIL total=${totalMs}ms attempts=${diag.attempts.length} finalErrorType=${finalErrorType}`, JSON.stringify(diag.attempts))
       return res.status(500).json({
-        error: '분석 결과를 읽지 못했어요. 다시 시도해주세요.',
+        error: '분석 결과를 받지 못했어요. 다시 시도해주세요.',
         errorType: finalErrorType,
         attempts: diag.attempts.length,
         durationMs: totalMs,

--- a/api/saju.js
+++ b/api/saju.js
@@ -109,9 +109,9 @@ function getAptSamples(gu, count = 2) {
 // ── Anthropic Tool Schema — 모델이 반드시 이 구조로 응답 ─────
 //   모든 string 필드에 maxLength 강제 → 출력 토큰 ↓ → 응답 시간 ↓
 //   (Anthropic Haiku tool-use가 28s 안에 안 끝나는 케이스 회피)
-const REASON_MAX = 60     // scoreBreakdown 4축 reason
-const SHORT_MAX  = 80     // jiming, dailyLife, summary 등
-const MED_MAX    = 150    // whyThisGu, regionComparison, finalVerdict
+const REASON_MAX = 70     // scoreBreakdown 4축 reason (풀어쓰기 여유)
+const SHORT_MAX  = 100    // jiming, dailyLife, summary 등
+const MED_MAX    = 180    // whyThisGu, regionComparison, finalVerdict
 
 export const SAJU_TOOL = {
   name: 'submit_saju_report',
@@ -165,21 +165,21 @@ export const SAJU_TOOL = {
             scoreBreakdown: {
               type: 'object',
               properties: {
-                ohaengMatch:   { type: 'object', properties: { score: { type: 'integer', minimum: 0, maximum: 25 }, reason: { type: 'string', maxLength: REASON_MAX } }, required: ['score','reason'] },
-                jimingOhaeng:  { type: 'object', properties: { score: { type: 'integer', minimum: 0, maximum: 25 }, reason: { type: 'string', maxLength: REASON_MAX } }, required: ['score','reason'] },
-                landscape:     { type: 'object', properties: { score: { type: 'integer', minimum: 0, maximum: 25 }, reason: { type: 'string', maxLength: REASON_MAX } }, required: ['score','reason'] },
-                lifeEnergy:    { type: 'object', properties: { score: { type: 'integer', minimum: 0, maximum: 25 }, reason: { type: 'string', maxLength: REASON_MAX } }, required: ['score','reason'] },
+                ohaengMatch:   { type: 'object', properties: { score: { type: 'integer', minimum: 0, maximum: 25 }, reason: { type: 'string', maxLength: REASON_MAX, description: '점수 이유 한 문장. 일상 언어로. 한자 오행·전문어 금지.' } }, required: ['score','reason'] },
+                jimingOhaeng:  { type: 'object', properties: { score: { type: 'integer', minimum: 0, maximum: 25 }, reason: { type: 'string', maxLength: REASON_MAX, description: '점수 이유 한 문장. 일상 언어로. 한자 오행·전문어 금지.' } }, required: ['score','reason'] },
+                landscape:     { type: 'object', properties: { score: { type: 'integer', minimum: 0, maximum: 25 }, reason: { type: 'string', maxLength: REASON_MAX, description: '점수 이유 한 문장. 일상 언어로. 한자 오행·전문어 금지.' } }, required: ['score','reason'] },
+                lifeEnergy:    { type: 'object', properties: { score: { type: 'integer', minimum: 0, maximum: 25 }, reason: { type: 'string', maxLength: REASON_MAX, description: '점수 이유 한 문장. 일상 언어로. 한자 오행·전문어 금지.' } }, required: ['score','reason'] },
               },
               required: ['ohaengMatch','jimingOhaeng','landscape','lifeEnergy'],
             },
-            jiming:    { type: 'string', maxLength: SHORT_MAX, description: '지명 풀이 (예: "麻浦(마포) — 浦자에 水변, 한강 포구")' },
-            whyThisGu: { type: 'string', maxLength: MED_MAX,   description: '이 구를 추천하는 이유 (사주와 연결, 1~2문장)' },
-            dailyLife: { type: 'string', maxLength: SHORT_MAX, description: '일상 생활 에너지 한 줄' },
+            jiming:    { type: 'string', maxLength: SHORT_MAX, description: '지명을 친근하게 풀이. 한자 의미를 한국어로 풀기. 예: "麻浦 — \'포구\'라는 뜻으로 한강 물기운이 담긴 동네"' },
+            whyThisGu: { type: 'string', maxLength: MED_MAX,   description: '이 구를 추천하는 이유 1~2문장. 일반인 일상 언어. 한자 오행(木火土金水)·사주 전문어(일간·신강·신약·용신·설기·비겁 등) 금지. 풍경·분위기·기분으로 풀어쓰기.' },
+            dailyLife: { type: 'string', maxLength: SHORT_MAX, description: '일상 생활 에너지 한 줄. 일반인이 공감할 일상 언어 (예: "한강 산책으로 하루 마무리, 출퇴근도 편한 동네")' },
           },
           required: ['gu','rank','score','scoreBreakdown','jiming','whyThisGu','dailyLife'],
         },
       },
-      regionComparison: { type: 'string', maxLength: MED_MAX,   description: '3개 구의 비교 한 줄' },
+      regionComparison: { type: 'string', maxLength: MED_MAX,   description: '3개 구의 비교 한 줄. 일반인 톤으로 (예: "마포는 한강 가까이, 용산은 산세 좋고, 영등포는 활기 강한 동네").' },
       warning: {
         type: 'object',
         properties: {
@@ -189,8 +189,8 @@ export const SAJU_TOOL = {
         },
         required: ['year','reason','action'],
       },
-      summary:      { type: 'string', maxLength: SHORT_MAX, description: '한 줄 요약' },
-      finalVerdict: { type: 'string', maxLength: MED_MAX,   description: '최종 판단 (1~2문장)' },
+      summary:      { type: 'string', maxLength: SHORT_MAX, description: '한 줄 요약. 일반인 톤. 한자 오행·전문어 금지.' },
+      finalVerdict: { type: 'string', maxLength: MED_MAX,   description: '최종 판단 1~2문장. 일반인 톤. 한자 오행·전문어 금지. (예: "지금 시기가 정착에 좋아요. 마포가 풍경·동네 분위기·교통 모두에서 가장 잘 맞습니다.")' },
     },
     required: ['ilgan','plainSummary','saju','timing','regions','regionComparison','warning','summary','finalVerdict'],
   },
@@ -265,10 +265,21 @@ ${pillarsInfo}
   · 점수 차이의 근거를 지명 오행·지형·생활 에너지 세 가지로 설명하세요
   · scoreBreakdown 4개 항목 점수 합이 score와 일치하도록 분배하세요
 
+[답변 톤 — 매우 중요]
+plainSummary뿐 아니라 reason·whyThisGu·dailyLife·jiming·regionComparison·summary·finalVerdict 모두 사주 모르는 일반인이 읽는 글입니다.
+- 한자 오행(木·火·土·金·水)을 단독으로 쓰지 말고 "나무 기운·물 기운·불 기운·쇠 기운·흙 기운" 으로
+- 사주 전문어("일간·신강·신약·설기·용신·비겁·식신·관성·재성·인성·세운·대운") 금지
+- 풍경·동네 분위기·생활 에너지·기분 같은 감각적 묘사로 풀어쓰기
+
+✗ 어려운 답: "한양도성 내 목기 강한 지세, 청계천 수 흐름과 남산 목 에너지 조화. 신강 목일간에 최적."
+✓ 쉬운 답: "남산의 푸른 산세와 청계천 물줄기가 어우러진 동네예요. 추진력 강한 당신에게 차분한 균형을 찾아주는 곳."
+
+(예외: saju 객체 안의 ohaengDist·sinkang·yongshin·yongShinReason·daewon·sewon은 전문 분석 필드라 한자·전문어 그대로 사용)
+
 [글자수 제한 — 응답 시간 단축]
-- 각 reason은 한 문장 60자 이내로 압축하세요
-- whyThisGu / regionComparison / finalVerdict 는 1~2문장 150자 이내
-- 핵심만 담고 부연·중복 표현은 제거하세요
+- 각 reason은 한 문장 70자 이내
+- whyThisGu / regionComparison / finalVerdict 는 1~2문장 180자 이내
+- 핵심만 담고 부연·중복 제거
 
 분석 결과는 반드시 submit_saju_report 도구로 제출하세요.`
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "granite dev",
     "build": "ait build",
     "preview": "vite preview",
-    "deploy": "ait deploy"
+    "deploy": "ait deploy",
+    "test": "node --test api/__tests__/*.test.js"
   },
   "dependencies": {
     "@amplitude/analytics-browser": "^2.41.0",


### PR DESCRIPTION
## Summary

`/api/saju` 가 production에서 500을 내던 문제 (`Unexpected non-whitespace character after JSON at position 2636`)와 그 과정에서 드러난 후속 안정성 이슈를 한 번에 정리합니다.

### 1. JSON 파싱 실패 → tool use 전환 (근본 원인 해결)
- 모델이 valid JSON 뒤에 자연어 부연설명을 붙이고, 그 안에 `}` 가 있어서 `lastIndexOf('}')` 가 잘못된 위치를 잡던 문제.
- Anthropic Messages API의 **tool use** 로 전환 — 응답이 `tool_use.input` 으로 이미 parsed 객체 형태로 도착. `JSON.parse` 호출이 코드에서 사라짐 → 파싱 에러 카테고리 자체 제거.
- Schema가 region 개수·점수 범위·일간/용신 enum 까지 강제. `regions.length === 3` 후처리 검사로 안전망.

### 2. cold-start 응답 시간 → 비대칭 timeout + 답변 슬림화
- Tool-use 응답이 cold-start 시 28s+ 가 걸려 `abort_28s × 2` 로 또 500이 나던 케이스 발견.
- **답변 자체를 줄임** — schema 모든 string 필드에 `maxLength`, `max_tokens` 4096 → 3000, prompt에 글자수 가이드.
- **비대칭 timeout** — 첫 시도 38s (cold-start P99 흡수) + 재시도 18s (transient 회복). 합 57s, Vercel 60s 한도 안.
- 검증: preview에서 17.9s 한 번에 OK, tokens_out 1863.

### 3. 답변 톤 → 일반인 친화
- "한양도성 내 목기 강한 지세, 청계천 수 흐름과 남산 목 에너지 조화" 같이 사주 모르는 사람은 못 읽던 답을, "남산의 푸른 산세와 청계천 물줄기가 어우러진 동네" 같은 일상 톤으로.
- `whyThisGu`, `jiming`, `dailyLife`, `scoreBreakdown.*.reason`, `regionComparison`, `summary`, `finalVerdict` 모두 schema description + prompt 가이드 + ✗/✓ 변환 예시로 강제.
- `saju` 객체 안의 전문 분석 필드 (`ohaengDist`, `sinkang`, `yongshin`, `yongShinReason`, `daewon`, `sewon`) 는 분석의 spine이라 한자/전문어 그대로 유지.

### 4. 결제 path 동시 정리
- `saju-confirm.js` 도 같은 tool-use 패턴으로 전환 — 별도 `submit_saju_premium_report` schema (vsOther 필드 보존).
- `processToolResponse` helper 공유.

### 5. 테스트
- node:test 기반 단위 테스트 29 케이스 추가 (`api/__tests__/saju.test.js`).
- 만세력 회귀 (1991.02.13 → 甲寅, 1996.08.27 → 丙申) + tool_use 추출 엣지케이스 + schema 무결성.
- `npm test` 로 재실행 가능.

## Test plan
- [x] 단위 테스트 29/29 통과
- [x] Preview 배포 검증 — tool use 정상 동작, 17.9s 응답
- [x] cold start 마진 — 38s 안에 안전 흡수 확인
- [x] 답변 톤 — 일반인 친화 결과 확인
- [ ] 머지 후 production smoke test — 본인 사주 1회 호출로 200/정상 결과 확인
- [ ] Vercel Logs에서 `[saju] OK` 로그 모니터링
