### PR TITLE
fix(saju): align client fetch timeout 55s → 60s

### DIFF
--- a/src/SajuPage.jsx
+++ b/src/SajuPage.jsx
@@ -252,7 +252,7 @@ function SajuLoading({ birthData, onResult, onError }) {
     const { year, month, day, si, gender } = birthData
     const clientStart = Date.now()
     const ctrl = new AbortController()
-    const tid  = setTimeout(() => ctrl.abort(), 55000)
+    const tid  = setTimeout(() => ctrl.abort(), 60000)
     fetch(`/api/saju?year=${year}&month=${month}&day=${day}&si=${si || ''}&gender=${gender}`, { signal: ctrl.signal })
       .then(r => r.json())
       .then(data => {


### PR DESCRIPTION
## Summary

PR #115 이후 backend worst case는 38s + 1s + 18s = **57s** 인데, 클라이언트 `SajuPage.jsx` 의 `fetchWithTimeout` 은 55s. cold + transient 누적되는 0.1% 미만 worst case에서 클라이언트가 백엔드보다 먼저 abort되는 잠재 미스매치 발견.

클라이언트 timeout 을 **60s** 로 올려서 Vercel `maxDuration` 한도와 정확히 일치시킴. backend 는 production 검증된 38+18 그대로 (Don't fix what works).

## Test plan
- [x] 정상 케이스 영향 없음 (15-25s 응답)
- [ ] 머지 후 production 자동 배포 확인